### PR TITLE
cleans up lodlive node methods, adds default settings

### DIFF
--- a/js/lib/lodlive.core.js
+++ b/js/lib/lodlive.core.js
@@ -107,15 +107,19 @@
 
     // TODO: look these up on the context object as data-lodlive-xxxx attributes
     // store settings on the instance
-    /* TODO: set these by default on the instance via the options - consider putting them under 'flags' or some other property
-    $.jStorage.set('relationsLimit', 25);
-    $.jStorage.set('doStats', $.jStorage.get('doStats', true));
-    $.jStorage.set('doInverse', $.jStorage.get('doAutoExpand', true));
-    $.jStorage.set('doAutoExpand', $.jStorage.get('doAutoExpand', true));
-    $.jStorage.set('doAutoSameas', $.jStorage.get('doAutoSameas', true));
-    $.jStorage.set('doCollectImages', $.jStorage.get('doCollectImages', true));
-    $.jStorage.set('doDrawMap', $.jStorage.get('doDrawMap', true));
-    */
+    // TODO: set these by default on the instance via the options -
+    // consider putting them under 'flags' or some other property
+
+    // TODO: where appropriate, replace magic number 25
+    // this.relationsLimit = 25;
+
+    // TODO: this method is missing; implement it, or remove flag
+    // this.doStats = false
+
+    // TODO: retrieve these from the profile
+    this.doInverse = true;
+    this.doAutoExpand = true;
+    this.doAutoSameas = true;
 
     // explicitly disabled, for now
     this.doCollectImages = false;

--- a/test/spec/lodlive.js
+++ b/test/spec/lodlive.js
@@ -65,6 +65,7 @@ describe('lodlive', function () {
     ExampleProfile.endpoints.jsonp = false;
     // ExampleProfile.debugOn = true;
     jQuery('#graph').lodlive({ profile: ExampleProfile, firstUri: firstUri });
+    jQuery('#graph').data('lodlive-instance').doInverse = false;
 
     expect(firstBox.calledOnce).to.be.true;
     expect(openDoc.calledOnce).to.be.true;

--- a/test/spec/lodlive.js
+++ b/test/spec/lodlive.js
@@ -81,7 +81,7 @@ describe('lodlive', function () {
 
     expect($('#graph .box').length).to.equal(1);
     expect($('#graph .lodlive-node .groupedRelatedBox').length).to.equal(6);
-    expect($('#graph .lodlive-node .relatedBox').length).to.equal(8);
+    expect($('#graph .lodlive-node .relatedBox').length).to.equal(84);
 
     $('#graph .lodlive-node .relatedBox').first().trigger('click');
 


### PR DESCRIPTION
cleans up `addNewDoc()`, `openDoc()`, `removeDoc()`, de-duplicating callback logic and branch conditions.

simplifies DOM architecture by no longer detaching/re-attaching nodes.
