### PR TITLE
updates test stub asserts

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       'node_modules/jquery/dist/jquery.js',
+      'node_modules/sinon-chai/lib/sinon-chai.js',
       'src/*.js',
       'js/deps/*.js',
       'js/lib/*.js',

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mocha": "^2.3.3",
     "phantomjs": "^1.9.18",
     "sinon": "^1.17.1",
+    "sinon-chai": "^2.8.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   }

--- a/test/spec/http-client.js
+++ b/test/spec/http-client.js
@@ -23,7 +23,7 @@ describe('httpClient', function () {
 
     httpClient({ query: 'QUERY' }, {})
 
-    expect(ajax.calledOnce).to.be.true
+    expect(ajax).to.have.been.calledOnce
 
     var args = ajax.args[0][0]
     expect(args.url).to.equal('endpoint?param=value&query=QUERY')
@@ -50,19 +50,19 @@ describe('httpClient', function () {
 
     httpClient({ query: 'QUERY' }, callbacks)
 
-    expect(ajax.calledOnce).to.be.true
+    expect(ajax).to.have.been.calledOnce
 
     var args = ajax.args[0][0]
 
     args.beforeSend()
-    expect(callbacks.beforeSend.calledOnce).to.be.true
+    expect(callbacks.beforeSend).to.have.been.calledOnce
 
     args.success()
-    expect(afterSend.calledOnce).to.be.true
-    expect(callbacks.success.calledOnce).to.be.true
+    expect(afterSend).to.have.been.calledOnce
+    expect(callbacks.success).to.have.been.calledOnce
 
     args.error()
-    expect(afterSend.calledTwice).to.be.true
-    expect(callbacks.error.calledOnce).to.be.true
+    expect(afterSend).to.have.been.calledTwice
+    expect(callbacks.error).to.have.been.calledOnce
   })
 })

--- a/test/spec/lodlive.js
+++ b/test/spec/lodlive.js
@@ -37,8 +37,8 @@ describe('lodlive', function () {
     ExampleProfile.endpoints.jsonp = false;
     jQuery('#graph').lodlive({ profile: ExampleProfile, firstUri: firstUri });
 
-    expect(firstBox.calledOnce).to.be.true;
-    expect(openDoc.calledOnce).to.be.true;
+    expect(firstBox).to.have.been.calledOnce;
+    expect(openDoc).to.have.been.calledOnce;
 
     expect(this.requests.length).to.equal(1);
     expect(this.requests[0].url).to.match(/^http:\/\/dbpedia.org\/sparql/);
@@ -66,8 +66,8 @@ describe('lodlive', function () {
     // ExampleProfile.debugOn = true;
     jQuery('#graph').lodlive({ profile: ExampleProfile, firstUri: firstUri });
 
-    expect(firstBox.calledOnce).to.be.true;
-    expect(openDoc.calledOnce).to.be.true;
+    expect(firstBox).to.have.been.calledOnce;
+    expect(openDoc).to.have.been.calledOnce;
 
     expect(this.requests.length).to.equal(1);
 
@@ -77,7 +77,7 @@ describe('lodlive', function () {
       JSON.stringify(this.fixtures.willSmith)
     );
 
-    expect(format.calledOnce).to.be.true;
+    expect(format).to.have.been.calledOnce;
 
     expect($('#graph .box').length).to.equal(1);
     expect($('#graph .lodlive-node .groupedRelatedBox').length).to.equal(6);
@@ -85,8 +85,8 @@ describe('lodlive', function () {
 
     $('#graph .lodlive-node .relatedBox').first().trigger('click');
 
-    expect(addNewDoc.calledOnce).to.be.true;
-    expect(openDoc.calledTwice).to.be.true;
+    expect(addNewDoc).to.have.been.calledOnce;
+    expect(openDoc).to.have.been.calledTwice;
 
     expect(this.requests.length).to.equal(2);
 
@@ -104,7 +104,7 @@ describe('lodlive', function () {
       JSON.stringify(this.fixtures.willSmith)
     );
 
-    expect(formatDoc.calledOnce).to.be.true;
+    expect(formatDoc).to.have.been.calledOnce;
 
     expect($('.lodlive-docinfo').length).to.equal(1);
     expect($('.lodlive-docinfo .section').length).to.equal(15);

--- a/test/spec/sparql-client.js
+++ b/test/spec/sparql-client.js
@@ -25,7 +25,7 @@ describe('sparqlClient', function () {
     var sparqlClient = sparqlClientFactory.create(profile, {}, httpStub)
 
     sparqlClient.document('', {})
-    expect(httpStub.calledOnce).to.be.true
+    expect(httpStub).to.have.been.calledOnce
     expect(httpStub.args[0][0].query).to.equal('QUERY')
   })
 
@@ -37,13 +37,13 @@ describe('sparqlClient', function () {
 
     sparqlClient.document('', { error: errorStub })
 
-    expect(httpStub.calledOnce).to.be.true
+    expect(httpStub).to.have.been.calledOnce
     expect(httpStub.args[0][0].query).to.equal('QUERY')
 
     var success = httpStub.args[0][1].success
     success({ results: { data: {} } })
 
-    expect(errorStub.calledOnce).to.be.true
+    expect(errorStub).to.have.been.calledOnce
     expect(errorStub.args[0][0]).to.match(/malformed results/)
   })
 
@@ -55,13 +55,13 @@ describe('sparqlClient', function () {
 
     sparqlClient.document('', { success: successStub })
 
-    expect(httpStub.calledOnce).to.be.true
+    expect(httpStub).to.have.been.calledOnce
     expect(httpStub.args[0][0].query).to.equal('QUERY')
 
     var success = httpStub.args[0][1].success
     success(this.fixtures.basicResults)
 
-    expect(successStub.calledOnce).to.be.true
+    expect(successStub).to.have.been.calledOnce
     var args = successStub.args[0][0];
 
     expect(args.uris.length).to.equal(1)
@@ -77,13 +77,13 @@ describe('sparqlClient', function () {
 
     sparqlClient.documentUri('', { error: errorStub })
 
-    expect(httpStub.calledOnce).to.be.true
+    expect(httpStub).to.have.been.calledOnce
     expect(httpStub.args[0][0].query).to.equal('QUERY')
 
     var success = httpStub.args[0][1].success
     success({ results: { data: {} } })
 
-    expect(errorStub.calledOnce).to.be.true
+    expect(errorStub).to.have.been.calledOnce
     expect(errorStub.args[0][0]).to.match(/malformed results/)
   })
 
@@ -95,13 +95,13 @@ describe('sparqlClient', function () {
 
     sparqlClient.documentUri('', { success: successStub })
 
-    expect(httpStub.calledOnce).to.be.true
+    expect(httpStub).to.have.been.calledOnce
     expect(httpStub.args[0][0].query).to.equal('QUERY')
 
     var success = httpStub.args[0][1].success
     success(this.fixtures.basicResults)
 
-    expect(successStub.calledOnce).to.be.true
+    expect(successStub).to.have.been.calledOnce
     var args = successStub.args[0][0];
 
     expect(args.uris.length).to.equal(1)
@@ -117,13 +117,13 @@ describe('sparqlClient', function () {
 
     sparqlClient.inverse('', { error: errorStub })
 
-    expect(httpStub.calledOnce).to.be.true
+    expect(httpStub).to.have.been.calledOnce
     expect(httpStub.args[0][0].query).to.equal('QUERY')
 
     var success = httpStub.args[0][1].success
     success({ results: { data: {} } })
 
-    expect(errorStub.calledOnce).to.be.true
+    expect(errorStub).to.have.been.calledOnce
     expect(errorStub.args[0][0]).to.match(/malformed results/)
   })
 
@@ -135,13 +135,13 @@ describe('sparqlClient', function () {
 
     sparqlClient.inverse('', { success: successStub })
 
-    expect(httpStub.calledOnce).to.be.true
+    expect(httpStub).to.have.been.calledOnce
     expect(httpStub.args[0][0].query).to.equal('QUERY')
 
     var success = httpStub.args[0][1].success
     success(this.fixtures.basicResults)
 
-    expect(successStub.calledOnce).to.be.true
+    expect(successStub).to.have.been.calledOnce
     var args = successStub.args[0][0];
 
     expect(args.uris.length).to.equal(1)
@@ -155,7 +155,7 @@ describe('sparqlClient', function () {
     var sparqlClient = sparqlClientFactory.create(profile, {}, httpStub)
 
     sparqlClient.inverseSameAs('', {})
-    expect(httpStub.calledOnce).to.be.true
+    expect(httpStub).to.have.been.calledOnce
     expect(httpStub.args[0][0].query).to.equal('QUERY')
   })
 
@@ -165,7 +165,7 @@ describe('sparqlClient', function () {
     var sparqlClient = sparqlClientFactory.create({}, defaultProfile, httpStub)
 
     sparqlClient.bnode('', {})
-    expect(httpStub.calledOnce).to.be.true
+    expect(httpStub).to.have.been.calledOnce
     expect(httpStub.args[0][0].query).to.equal('QUERY')
   })
 
@@ -175,7 +175,7 @@ describe('sparqlClient', function () {
     var sparqlClient = sparqlClientFactory.create(profile, {}, httpStub)
 
     sparqlClient.inverse('test', {})
-    expect(httpStub.calledOnce).to.be.true
+    expect(httpStub).to.have.been.calledOnce
     expect(httpStub.args[0][0].query).to.equal('QUERY test')
   })
 })


### PR DESCRIPTION
switches test specs to use sinon-chai for stub assertions, which gives more precise error messages (the existing approach just showed a boolean mismatch, without even a line number).
