### PR TITLE
refactors node and predicate-node rendering

### DIFF
--- a/css/ml-lodlive.css
+++ b/css/ml-lodlive.css
@@ -4,7 +4,7 @@
   overflow: scroll;
   background-color: #c7c7c7;
   font-family: 'Open Sans', Verdana, sans-serif;
-  font-size: 10px; 
+  font-size: 10px;
   position: relative;
 }
 
@@ -29,7 +29,7 @@
   width: 0;
 }
 
-.lodlive-node .lodlive-node-label{ 
+.lodlive-node .lodlive-node-label {
   width: 126px;
   height: 126px;
   position: relative;
@@ -133,7 +133,26 @@
   border-radius: 0 8px 0 0;
 }
 
-
 .lodlive-node.pinned .lodlive-node-label { border: dashed 1px white; background-color: #9CF; }
 
+.lodlive-node .page .pageNext {
+  background-position: -1390px -412px;
+  cursor: pointer;
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 0;
+  z-index: 101;
+  text-align: center;
+}
 
+.lodlive-node .page .pagePrev {
+  background-position: -1414px -410px;
+  cursor: pointer;
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 0;
+  z-index: 101;
+  text-align: center;
+}

--- a/js/lib/lodlive.core.js
+++ b/js/lib/lodlive.core.js
@@ -775,86 +775,6 @@
     // var connectedLongs = [];
     // var connectedLats = [];
 
-    var sameDocControl = [];
-    $.each(uris, function(key, value) {
-      for (var akey in value) {
-
-        // escludo la definizione della classe, le proprieta'
-        // relative alle immagini ed ai link web
-        if (lodLiveProfile.uriSubstitutor) {
-          $.each(lodLiveProfile.uriSubstitutor, function(skey, svalue) {
-            value[akey] = value[akey].replace(svalue.findStr, svalue.replaceStr);
-          });
-        }
-        if ($.inArray(akey, images) > -1) {
-          //FIXME: replace eval
-          eval('connectedImages.push({\'' + value[akey] + '\':\'' + escape(resourceTitle) + '\'})');
-
-        } else if ($.inArray(akey, weblinks) == -1) {
-
-          // controllo se trovo la stessa relazione in una
-          // proprieta' diversa
-          if ($.inArray(value[akey], sameDocControl) > -1) {
-
-            var aCounter = 0;
-            $.each(connectedDocs, function(key2, value2) {
-              for (var akey2 in value2) {
-                if (value2[akey2] == value[akey]) {
-                  eval('connectedDocs[' + aCounter + '] = {\'' + akey2 + ' | ' + akey + '\':\'' + value[akey] + '\'}');
-                }
-              }
-              aCounter++;
-            });
-
-          } else {
-            //FIXME: replace eval
-            eval('connectedDocs.push({\'' + akey + '\':\'' + value[akey] + '\'})');
-            sameDocControl.push(value[akey]);
-          }
-
-        }
-      }
-
-    });
-
-    if (inverses) {
-      sameDocControl = [];
-      $.each(inverses, function(key, value) {
-        for (var akey in value) {
-          if (docType == 'bnode' && value[akey].indexOf('~~') != -1) {
-            continue;
-          }
-          if (lodLiveProfile.uriSubstitutor) {
-            $.each(lodLiveProfile.uriSubstitutor, function(skey, svalue) {
-              value[akey] = value[akey].replace(escape(svalue.findStr), escape(svalue.replaceStr));
-            });
-          }
-          // controllo se trovo la stessa relazione in una
-          // proprieta' diversa
-          if ($.inArray(value[akey], sameDocControl) > -1) {
-            var aCounter = 0;
-            $.each(invertedDocs, function(key2, value2) {
-              for (var akey2 in value2) {
-                if (value2[akey2] == value[akey]) {
-                  var theKey = akey2;
-                  if (akey2 != akey) {
-                    theKey = akey2 + ' | ' + akey;
-                  }
-                  eval('invertedDocs[' + aCounter + '] = {\'' + theKey + '\':\'' + value[akey] + '\'}');
-                  return false;
-                }
-              }
-              aCounter++;
-            });
-          } else {
-            eval('invertedDocs.push({\'' + akey + '\':\'' + value[akey] + '\'})');
-            sameDocControl.push(value[akey]);
-          }
-
-        }
-      });
-    }
-
     function groupByObject(inputArray, type) {
       var tmpIRIs = {};
       var outputArray = [];
@@ -895,69 +815,10 @@
       return outputArray;
     }
 
-    var myConnectedDocs = [];
-    var myInvertedDocs = [];
-
-    myConnectedDocs = groupByObject(uris, 'uris');
+    connectedDocs = groupByObject(uris, 'uris');
     if (inverses) {
-      myInvertedDocs = groupByObject(inverses, 'inverses');
+      invertedDocs = groupByObject(inverses, 'inverses');
     }
-
-    var myConnectedEqual = deepCompare(connectedDocs, myConnectedDocs);
-    console.log('connected: ' + myConnectedEqual)
-    if (!myConnectedEqual) {
-      connectedDocs.forEach(function(obj, i) {
-        if (!deepCompare(obj, myConnectedDocs[i])) {
-          console.log(obj, myConnectedDocs[i])
-        }
-      })
-    }
-
-    var myInvertedEqual = deepCompare(invertedDocs, myInvertedDocs)
-    console.log('inverted: ' + myInvertedEqual)
-    if (!myInvertedEqual) {
-      invertedDocs.forEach(function(obj, i) {
-        if (!deepCompare(obj, myInvertedDocs[i])) {
-          console.log(obj, myInvertedDocs[i])
-        }
-      })
-    }
-
-    // if (totRelated > 16) {
-      $.each(connectedDocs, function(key, value) {
-        for (var akey in value) {
-          if (propertyGroup[akey]) {
-            var t = propertyGroup[akey];
-            t.push(value[akey]);
-            propertyGroup[akey] = t;
-          } else {
-            propertyGroup[akey] = [value[akey]];
-          }
-        }
-      });
-      $.each(invertedDocs, function(key, value) {
-        for (var akey in value) {
-          if (propertyGroupInverted[akey]) {
-            var t = propertyGroupInverted[akey];
-            t.push(value[akey]);
-            propertyGroupInverted[akey] = t;
-          } else {
-            propertyGroupInverted[akey] = [value[akey]];
-          }
-        }
-      });
-    //   totRelated = 0;
-    //   for (var prop in propertyGroup) {
-    //     if (propertyGroup.hasOwnProperty(prop)) {
-    //       totRelated++;
-    //     }
-    //   }
-    //   for (var prop in propertyGroupInverted) {
-    //     if (propertyGroupInverted.hasOwnProperty(prop)) {
-    //       totRelated++;
-    //     }
-    //   }
-    // }
 
     function groupByPropertyKey(inputArray) {
       var group = {};
@@ -979,29 +840,9 @@
     }
 
     // group URIs by property key
-    var myPropertyGroup = groupByPropertyKey(connectedDocs);
+    propertyGroup = groupByPropertyKey(connectedDocs);
     // group inverse URIs by property key
-    var myPropertyGroupInverted = groupByPropertyKey(invertedDocs);
-
-    var myGroupEqual = deepCompare(propertyGroup, myPropertyGroup);
-    console.log('group: ' + myGroupEqual)
-    if (!myGroupEqual) {
-      Object.keys(propertyGroup).forEach(function(key) {
-        if (!deepCompare(propertyGroup[key], myPropertyGroup[key])) {
-          console.log(propertyGroup[key], myPropertyGroup[key])
-        }
-      })
-    }
-
-    var myInvertedGroupEqual = deepCompare(propertyGroupInverted, myPropertyGroupInverted)
-    console.log('inverted group: ' + myInvertedGroupEqual)
-    if (!myInvertedGroupEqual) {
-      Object.keys(propertyGroupInverted).forEach(function(key) {
-        if (!deepCompare(propertyGroupInverted[key], myPropertyGroupInverted[key])) {
-          console.log(propertyGroupInverted[key], myPropertyGroupInverted[key])
-        }
-      })
-    }
+    propertyGroupInverted = groupByPropertyKey(invertedDocs);
 
     // Map rendering has been disabled; keeping for posterity ...
     // if (inst.doDrawMap) {
@@ -1064,20 +905,9 @@
     var chordsList = inst.circleChords(75, 24, destBox.position().left + 65, destBox.position().top + 65);
     var chordsListGrouped = inst.circleChords(95, 36, destBox.position().left + 65, destBox.position().top + 65);
 
-    // console.log(chordsList)
-    // console.log(chordsListGrouped)
-
-    var counterSanityCheck = {
-      group: [],
-      related: []
-    }
-    var newCounterSanityCheck = {
-      group: [],
-      related: []
-    }
-
+    // iterates over connectedDocs and invertedDocs, creating DOM nodes and calculating CSS positioning
     function createPropertyBoxes(inputArray, inputGroup, isInverse) {
-      var a = 1;
+      var counter = 1;
       var inserted = {};
       var innerCounter = 1;
       var objectList = [];
@@ -1085,43 +915,39 @@
 
       inputArray.forEach(function(value, i) {
         // TODO: refactor; modular arithmetic for CSS positioning
-        // a appears to equal the count of groupedProperties mod 14 plus 1 or 2
-        if (a === 15) {
-          a = 1;
+        // counter appears to equal the count of groupedProperties mod 14 plus 1 or 2
+        if (counter === 15) {
+          counter = 1;
         }
 
         // TODO: ensure only one key?
-        var akey = Object.keys(value)[0];
+        var key = Object.keys(value)[0];
         var obj = null;
 
-        if (inputGroup[akey] && inputGroup[akey].length > 1) {
-          if (!inserted[akey]) {
+        if (inputGroup[key] && inputGroup[key].length > 1) {
+          if (!inserted[key]) {
             innerCounter = 1;
-            inserted[akey] = true;
+            inserted[key] = true;
 
-            var objBox = createPropertyGroup(akey, inputGroup[akey], a, isInverse);
+            var objBox = createPropertyGroup(key, inputGroup[key], counter, isInverse);
             objectList.push(objBox);
-            newCounterSanityCheck.related.push(a)
-
-            a++;
+            counter++;
           }
 
           // TODO: magic number; why 25?
           if (innerCounter < 25) {
-            obj = createGroupedRelatedBox(akey, value[akey], innerCounter, isInverse);
-            newCounterSanityCheck.group.push(innerCounter)
+            obj = createGroupedRelatedBox(key, value[key], innerCounter, isInverse);
           }
 
           innerCounter++;
         } else {
-          obj = createRelatedBox(akey, value[akey], a, isInverse);
-          newCounterSanityCheck.related.push(a)
-          a++;
+          obj = createRelatedBox(key, value[key], counter, isInverse);
+          counter++;
         }
 
         // TODO: when will object be null? innerCounter >= 25?
         if (obj) {
-          addRelatedBoxProperties(obj, akey, containerBox, isInverse);
+          addRelatedBoxProperties(obj, key, containerBox, isInverse);
 
           if (obj.hasClass('aGrouped')) {
             innerObjectList.push(obj);
@@ -1138,426 +964,117 @@
     }
 
     // create a node to represent a group of related properties (star-circle)
-    function createPropertyGroup(akey, groupValue, aCounter, isInverse) {
+    function createPropertyGroup(key, groupValue, counter, isInverse) {
       var objBox = $('<div></div>')
 
-      objBox.addClass('groupedRelatedBox')
-      objBox.attr('rel', inst.hashFunc(akey))
-      objBox.attr('data-property', akey)
-      objBox.attr('data-title', akey + ' \n ' + (groupValue.length) + ' ' + utils.lang('connectedResources'))
-      objBox.css(inst.getRelationshipCSS(akey));
+      .addClass('groupedRelatedBox')
+      .attr('rel', inst.hashFunc(key))
+      .attr('data-property', key)
+      .attr('data-title', key + ' \n ' + (groupValue.length) + ' ' + utils.lang('connectedResources'))
+      .css(inst.getRelationshipCSS(key))
+      .css({
+        'top':  (chordsList[counter][1] - 8) + 'px',
+        'left': (chordsList[counter][0] - 8) + 'px'
+      });
 
       if (isInverse) {
-        objBox.addClass('inverse')
-        objBox.attr('rel', inst.hashFunc(akey) + '-i')
+        objBox.addClass('inverse');
+        objBox.attr('rel', inst.hashFunc(key) + '-i');
       }
 
-      var akeyArray = akey.split(' ');
+      var keyArray = key.split(' ');
 
-      if (unescape(groupValue[0]).indexOf('~~') != -1) {
+      if (unescape(groupValue[0]).indexOf('~~') > -1) {
         objBox.addClass('isBnode');
       } else {
-        for (var i = 0; i < akeyArray.length; i++) {
-          if (lodLiveProfile.arrows[akeyArray[i]]) {
-            objBox.addClass(lodLiveProfile.arrows[akeyArray[i]]);
+        for (var i = 0; i < keyArray.length; i++) {
+          if (lodLiveProfile.arrows[keyArray[i]]) {
+            objBox.addClass(lodLiveProfile.arrows[keyArray[i]]);
           }
         }
       }
-
-      objBox.css({
-        'top':  (chordsList[aCounter][1] - 8) + 'px',
-        'left': (chordsList[aCounter][0] - 8) + 'px'
-      });
 
       return objBox;
     }
 
     // create a node to represent a property in a group of related properties
-    function createGroupedRelatedBox(akey, keyedValue, innerCounter, isInverse) {
+    function createGroupedRelatedBox(key, keyedValue, innerCounter, isInverse) {
       var rel;
 
       // TODO: this seems inlikely... the bnode marker isn't ever at the beginning of keyedValue
       // is the condition a typo?
       if (isInverse) {
-        rel = unescape(keyedValue.indexOf('~~') == 0 ? thisUri + keyedValue : keyedValue);
+        rel = unescape(keyedValue.indexOf('~~') === 0 ? thisUri + keyedValue : keyedValue);
       } else {
         rel = unescape(keyedValue)
       }
 
       var obj = $('<div></div>')
-
-      obj.addClass('aGrouped relatedBox');
-      obj.attr('rel', rel)
-      obj.attr('data-title', akey + ' \n ' + unescape(keyedValue))
-      obj.attr('data-circlePos', innerCounter);
-      obj.attr('data-circleParts', 36);
-      // obj.css({
-      //   display: 'none',
-      //   position: 'absolute',
-      //   top: (chordsListGrouped[innerCounter][1] - 8) + 'px',
-      //   left: (chordsListGrouped[innerCounter][0] - 8) + 'px'
-      // });
-      obj.attr('style', 'display: none; position: absolute; top: ' + (chordsListGrouped[innerCounter][1] - 8) + 'px; left: ' + (chordsListGrouped[innerCounter][0] - 8) + 'px;');
+      .addClass('aGrouped relatedBox ' + inst.hashFunc(unescape(keyedValue)).toString())
+      .attr('rel', rel)
+      .attr('data-title', key + ' \n ' + unescape(keyedValue))
+      .attr('data-circlePos', innerCounter)
+      .attr('data-circleParts', 36)
+      .css({
+        display: 'none',
+        position: 'absolute',
+        top: (chordsListGrouped[innerCounter][1] - 8) + 'px',
+        left: (chordsListGrouped[innerCounter][0] - 8) + 'px'
+      });
 
       if (isInverse) {
-        obj.addClass('inverse ' + inst.hashFunc(akey) + '-i')
+        obj.addClass('inverse ' + inst.hashFunc(key) + '-i');
       } else {
-        obj.addClass(inst.hashFunc(akey).toString())
+        obj.addClass(inst.hashFunc(key).toString());
       }
-
-      obj.addClass(inst.hashFunc(unescape(keyedValue)).toString())
 
       return obj;
     }
 
     // create a node to represent a related property
-    function createRelatedBox(akey, keyedValue, aCounter, isInverse) {
+    function createRelatedBox(key, keyedValue, counter, isInverse) {
       var obj = $('<div></div>')
-
-      obj.addClass('relatedBox')
-      obj.attr('rel', unescape(keyedValue))
-      obj.attr('data-title', akey + ' \n ' + unescape(keyedValue))
-      obj.attr('data-circlePos', aCounter);
-      obj.attr('data-circleParts', 24);
-      // obj.css({
-      //   top: (chordsList[a][1] - 8) + 'px',
-      //   left: (chordsList[a][0] - 8) + 'px'
-      // })
-      obj.attr('style', 'top: ' + (chordsList[aCounter][1] - 8) + 'px; left: ' + (chordsList[aCounter][0] - 8) + 'px;');
+      .addClass('relatedBox ' + inst.hashFunc(unescape(keyedValue)).toString())
+      .attr('rel', unescape(keyedValue))
+      .attr('data-title', key + ' \n ' + unescape(keyedValue))
+      .attr('data-circlePos', counter)
+      .attr('data-circleParts', 24)
+      .css({
+        top: (chordsList[counter][1] - 8) + 'px',
+        left: (chordsList[counter][0] - 8) + 'px'
+      });
 
       if (isInverse) {
-        obj.addClass('inverse')
+        obj.addClass('inverse');
       }
-
-      obj.addClass(inst.hashFunc(unescape(keyedValue)).toString())
 
       return obj;
     }
 
-    function addRelatedBoxProperties(obj, akey, containerBox, isInverse) {
-      obj.attr('data-circleid', containerBox.attr('id'));
-      obj.attr('data-property', akey);
-      obj.css(inst.getRelationshipCSS(akey));
+    function addRelatedBoxProperties(obj, key, containerBox, isInverse) {
+      obj.attr('data-circleid', containerBox.attr('id'))
+      .attr('data-property', key)
+      .css(inst.getRelationshipCSS(key));
+
       // se si tratta di un  Bnode applico una classe diversa
-      var akeyArray = akey.split(' ');
-      if (obj.attr('rel').indexOf('~~') != -1) {
+      var keyArray = key.split(' ');
+      if (obj.attr('rel').indexOf('~~') > -1) {
         obj.addClass('isBnode');
       } else {
-        for (var i = 0; i < akeyArray.length; i++) {
-          if (lodLiveProfile.arrows[akeyArray[i]]) {
-            obj.addClass(lodLiveProfile.arrows[akeyArray[i]]);
+        for (var i = 0; i < keyArray.length; i++) {
+          if (lodLiveProfile.arrows[keyArray[i]]) {
+            obj.addClass(lodLiveProfile.arrows[keyArray[i]]);
           }
         }
       }
     }
 
-    var connectedDocsLists = createPropertyBoxes(connectedDocs, propertyGroup, false);
-    var invertedDocsLists = createPropertyBoxes(invertedDocs, propertyGroupInverted, true);
+    var connectedNodes = createPropertyBoxes(connectedDocs, propertyGroup, false);
+    var invertedNodes = createPropertyBoxes(invertedDocs, propertyGroupInverted, true);
 
     // aggiungo al box i link ai documenti correlati
-    var objectList = [];
-    var innerObjectList = [];
-
-    var a = 1;
-    var inserted = {};
-    var counter = 0;
-    var innerCounter = 1;
-
-    var isInverse = false;
-
-    $.each(connectedDocs, function(key, value) {
-
-      // TODO: remove; appears to be unused
-      if (counter == 16) {
-        counter = 0;
-      }
-
-      // TODO: refactor; modular arithmetic for CSS positioning
-      if (a == 1) {
-      } else if (a == 15) {
-        a = 1;
-      }
-
-      for (var akey in value) {
-        var obj = null;
-        if (propertyGroup[akey] && propertyGroup[akey].length > 1) {
-          if (!inserted[akey]) {
-            innerCounter = 1;
-            inserted[akey] = true;
-            var objBox = $('<div class="groupedRelatedBox" rel="' + inst.hashFunc(akey) + '" data-property="' + akey + '"  data-title="' + akey + ' \n ' + (propertyGroup[akey].length) + ' ' + utils.lang('connectedResources') + '" ></div>');
-            objBox.css(inst.getRelationshipCSS(akey));
-            // containerBox.append(objBox);
-            var akeyArray = akey.split(' ');
-            if (unescape(propertyGroup[akey][0]).indexOf('~~') != -1) {
-              objBox.addClass('isBnode');
-            } else {
-              for (var i = 0; i < akeyArray.length; i++) {
-                if (lodLiveProfile.arrows[akeyArray[i]]) {
-                  objBox.addClass(lodLiveProfile.arrows[akeyArray[i]]);
-                }
-              }
-            }
-            objBox.css({
-              'top':  (chordsList[a][1] - 8) + 'px',
-              'left': (chordsList[a][0] - 8) + 'px'
-            });
-
-            var myObjBox = createPropertyGroup(akey, propertyGroup[akey], a, isInverse);
-            if (!deepCompare(objBox[0].outerHTML, myObjBox[0].outerHTML)) {
-              console.log(objBox[0].outerHTML)
-              console.log(myObjBox[0].outerHTML)
-            }
-
-            objectList.push(objBox);
-
-            a++;
-            counter++;
-          }
-
-          if (innerCounter < 25) {
-            obj = $('<div class="aGrouped relatedBox ' + inst.hashFunc(akey) + ' ' + inst.hashFunc(unescape(value[akey])) + '" rel="' + unescape(value[akey]) + '"  data-title="' + akey + ' \n ' + unescape(value[akey]) + '" ></div>');
-            // containerBox.append(obj);
-            obj.attr('data-circlePos', innerCounter);
-            obj.attr('data-circleParts', 36);
-            obj.attr('style', 'display: none; position: absolute; top: ' + (chordsListGrouped[innerCounter][1] - 8) + 'px; left: ' + (chordsListGrouped[innerCounter][0] - 8) + 'px;');
-            obj.attr('data-circleid', containerBox.attr('id'));
-
-            var myObj = createGroupedRelatedBox(akey, value[akey], innerCounter, isInverse);
-            // if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
-            //   console.log(obj[0].outerHTML)
-            //   console.log(myObj[0].outerHTML)
-            // }
-
-            counterSanityCheck.group.push(innerCounter)
-
-          }
-
-          innerCounter++;
-        } else {
-          obj = $('<div class="relatedBox ' + inst.hashFunc(unescape(value[akey])) + '" rel="' + unescape(value[akey]) + '" data-title="' + akey + ' \n ' + unescape(value[akey]) + '"></div>');
-          // containerBox.append(obj);
-          obj.attr('data-circlePos', a);
-          obj.attr('data-circleParts', 24);
-          obj.attr('style', 'top: ' + (chordsList[a][1] - 8) + 'px; left: ' + (chordsList[a][0] - 8) + 'px;');
-
-          var myObj = createRelatedBox(akey, value[akey], a, isInverse);
-          // if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
-          //   console.log(obj[0].outerHTML)
-          //   console.log(myObj[0].outerHTML)
-          // }
-
-          counterSanityCheck.related.push(a)
-
-          a++;
-          counter++;
-        }
-        if (obj) {
-          obj.attr('data-circleid', containerBox.attr('id'));
-          obj.attr('data-property', akey);
-          obj.css(inst.getRelationshipCSS(akey));
-          // se si tratta di un  Bnode applico una classe diversa
-          var akeyArray = akey.split(' ');
-          if (obj.attr('rel').indexOf('~~') != -1) {
-            obj.addClass('isBnode');
-          } else {
-            for (var i = 0; i < akeyArray.length; i++) {
-              if (lodLiveProfile.arrows[akeyArray[i]]) {
-                obj.addClass(lodLiveProfile.arrows[akeyArray[i]]);
-              }
-            }
-          }
-
-          addRelatedBoxProperties(myObj, akey, containerBox, isInverse);
-
-          if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
-            console.log(obj[0].outerHTML)
-            console.log(myObj[0].outerHTML)
-          }
-
-          if (obj.hasClass('aGrouped')) {
-            innerObjectList.push(obj);
-          } else {
-            objectList.push(obj);
-          }
-        }
-      }
-
-    });
-
-    console.log('connectedDocs/object: ' + objectList.length)
-    console.log('connectedDocs/newObject: ' + connectedDocsLists.objectList.length)
-
-    objectList.forEach(function(obj, i) {
-      if (!deepCompare(obj[0].outerHTML, connectedDocsLists.objectList[i][0].outerHTML)) {
-        console.log(obj[0].outerHTML)
-        console.log(connectedDocsLists.objectList[i][0].outerHTML)
-      }
-    })
-
-    console.log('connectedDocs/innerObject: ' + innerObjectList.length)
-    console.log('connectedDocs/newInnerObject: ' + connectedDocsLists.innerObjectList.length)
-
-    innerObjectList.forEach(function(obj, i) {
-      if (!deepCompare(obj[0].outerHTML, connectedDocsLists.innerObjectList[i][0].outerHTML)) {
-        console.log(obj[0].outerHTML)
-        console.log(connectedDocsLists.innerObjectList[i][0].outerHTML)
-      }
-    })
-
-    isInverse = true;
-    a = 1;
-
-    inserted = {};
-    $.each(invertedDocs, function(key, value) {
-
-      // TODO: remove; appears to be unused
-      if (counter == 16) {
-        counter = 0;
-      }
-
-      // TODO: refactor; modular arithmetic for CSS positioning
-      if (a == 1) {
-      } else if (a == 15) {
-        a = 1;
-      }
-
-      for (var akey in value) {
-        var obj = null;
-        if (propertyGroupInverted[akey] && propertyGroupInverted[akey].length > 1) {
-          if (!inserted[akey]) {
-            innerCounter = 1;
-            inserted[akey] = true;
-
-            var objBox = $('<div class="groupedRelatedBox inverse" rel="' + inst.hashFunc(akey) + '-i"   data-property="' + akey + '" data-title="' + akey + ' \n ' + (propertyGroupInverted[akey].length) + ' ' + utils.lang('connectedResources') + '" ></div>');
-            objBox.css(inst.getRelationshipCSS(akey));
-            // containerBox.append(objBox);
-            var akeyArray = akey.split(' ');
-            if (unescape(propertyGroupInverted[akey][0]).indexOf('~~') != -1) {
-              objBox.addClass('isBnode');
-            } else {
-              for (var i = 0; i < akeyArray.length; i++) {
-                if (lodLiveProfile.arrows[akeyArray[i]]) {
-                  objBox.addClass(lodLiveProfile.arrows[akeyArray[i]]);
-                }
-              }
-            }
-            objBox.css({
-              'top': + (chordsList[a][1] - 8) + 'px',
-              'left': + (chordsList[a][0] - 8) + 'px'
-            });
-
-            var myObjBox = createPropertyGroup(akey, propertyGroupInverted[akey], a, isInverse);
-            if (!deepCompare(objBox[0].outerHTML, myObjBox[0].outerHTML)) {
-              console.log(objBox[0].outerHTML)
-              console.log(myObjBox[0].outerHTML)
-            }
-
-            objectList.push(objBox);
-            a++;
-            counter++;
-          }
-
-          if (innerCounter < 25) {
-            var destUri = unescape(value[akey].indexOf('~~') == 0 ? thisUri + value[akey] : value[akey]);
-            obj = $('<div class="aGrouped relatedBox inverse ' + inst.hashFunc(akey) + '-i ' + inst.hashFunc(unescape(value[akey])) + '" rel="' + destUri + '"  data-title="' + akey + ' \n ' + unescape(value[akey]) + '" ></div>');
-            // containerBox.append(obj);
-            obj.attr('data-circlePos', innerCounter);
-            obj.attr('data-circleParts', 36);
-            // obj.attr('data-circleId', containerBox.attr('id'));
-            obj.attr('style', 'display: none; position: absolute; top: ' + (chordsListGrouped[innerCounter][1] - 8) + 'px; left: ' + (chordsListGrouped[innerCounter][0] - 8) + 'px;');
-
-            var myObj = createGroupedRelatedBox(akey, value[akey], innerCounter, isInverse);
-            if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
-              console.log(obj[0].outerHTML)
-              console.log(myObj[0].outerHTML)
-            }
-
-            counterSanityCheck.group.push(innerCounter)
-          }
-
-          innerCounter++;
-        } else {
-          obj = $('<div class="relatedBox inverse ' + inst.hashFunc(unescape(value[akey])) + '" rel="' + unescape(value[akey]) + '"   data-title="' + akey + ' \n ' + unescape(value[akey]) + '" ></div>');
-          // containerBox.append(obj);
-          obj.attr('data-circlePos', a);
-          obj.attr('data-circleParts', 24);
-          obj.attr('style', 'top: ' + (chordsList[a][1] - 8) + 'px; left: ' + (chordsList[a][0] - 8) + 'px;');
-
-          var myObj = createRelatedBox(akey, value[akey], a, isInverse);
-          if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
-            console.log(obj[0].outerHTML)
-            console.log(myObj[0].outerHTML)
-          }
-
-          counterSanityCheck.related.push(a)
-
-          a++;
-          counter++;
-        }
-        if (obj) {
-          obj.attr('data-circleId', containerBox.attr('id'));
-          obj.attr('data-property', akey);
-          obj.css(inst.getRelationshipCSS(akey));
-          // se si tratta di un sameas applico una classe diversa
-          var akeyArray = akey.split(' ');
-
-          if (obj.attr('rel').indexOf('~~') != -1) {
-            obj.addClass('isBnode');
-          } else {
-            for (var i = 0; i < akeyArray.length; i++) {
-              if (lodLiveProfile.arrows[akeyArray[i]]) {
-                obj.addClass(lodLiveProfile.arrows[akeyArray[i]]);
-              }
-            }
-          }
-
-          addRelatedBoxProperties(myObj, akey, containerBox, isInverse);
-
-          if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
-            console.log(obj[0].outerHTML)
-            console.log(myObj[0].outerHTML)
-          }
-
-          if (obj.hasClass('aGrouped')) {
-            innerObjectList.push(obj);
-          } else {
-            objectList.push(obj);
-          }
-        }
-      }
-
-    });
-
-    // objectList = connectedDocsLists.objectList.concat(invertedDocsLists.objectList);
-    // innerObjectList = connectedDocsLists.innerObjectList.concat(invertedDocsLists.innerObjectList);
-
-    var combinedObjects = connectedDocsLists.objectList.concat(invertedDocsLists.objectList);
-    var combinedInnerObjects = connectedDocsLists.innerObjectList.concat(invertedDocsLists.innerObjectList)
-
-    console.log('objects: ' + objectList.length)
-    console.log('newObjects: ' + combinedObjects.length)
-
-    objectList.forEach(function(obj, i) {
-      if (!deepCompare(obj[0].outerHTML, combinedObjects[i][0].outerHTML)) {
-        console.log(i)
-        console.log(obj[0].outerHTML)
-        console.log(combinedObjects[i][0].outerHTML)
-      }
-    })
-
-    console.log('innerObjects: ' + innerObjectList.length)
-    console.log('newInnerObjects: ' + combinedInnerObjects.length)
-
-    innerObjectList.forEach(function(obj, i) {
-      if (!deepCompare(obj[0].outerHTML, combinedInnerObjects[i][0].outerHTML)) {
-        console.log(i)
-        console.log(obj[0].outerHTML)
-        console.log(combinedInnerObjects[i][0].outerHTML)
-      }
-    })
-
-    objectList = connectedDocsLists.objectList.concat(invertedDocsLists.objectList);
-    innerObjectList = connectedDocsLists.innerObjectList.concat(invertedDocsLists.innerObjectList);
+    var objectList = connectedNodes.objectList.concat(invertedNodes.objectList);
+    var innerObjectList = connectedNodes.innerObjectList.concat(invertedNodes.innerObjectList);
 
     var page = 0;
     var totPages = objectList.length > 14 ? (objectList.length / 14 + (objectList.length % 14 > 0 ? 1 : 0)) : 1;
@@ -1827,118 +1344,3 @@
   };
 
 })(jQuery);
-
-function deepCompare () {
-  var i, l, leftChain, rightChain;
-
-  function compare2Objects (x, y) {
-    var p;
-
-    // remember that NaN === NaN returns false
-    // and isNaN(undefined) returns true
-    if (isNaN(x) && isNaN(y) && typeof x === 'number' && typeof y === 'number') {
-         return true;
-    }
-
-    // Compare primitives and functions.
-    // Check if both arguments link to the same object.
-    // Especially useful on step when comparing prototypes
-    if (x === y) {
-        return true;
-    }
-
-    // Works in case when functions are created in constructor.
-    // Comparing dates is a common scenario. Another built-ins?
-    // We can even handle functions passed across iframes
-    if ((typeof x === 'function' && typeof y === 'function') ||
-       (x instanceof Date && y instanceof Date) ||
-       (x instanceof RegExp && y instanceof RegExp) ||
-       (x instanceof String && y instanceof String) ||
-       (x instanceof Number && y instanceof Number)) {
-        return x.toString() === y.toString();
-    }
-
-    // At last checking prototypes as good a we can
-    if (!(x instanceof Object && y instanceof Object)) {
-        return false;
-    }
-
-    if (x.isPrototypeOf(y) || y.isPrototypeOf(x)) {
-        return false;
-    }
-
-    if (x.constructor !== y.constructor) {
-        return false;
-    }
-
-    if (x.prototype !== y.prototype) {
-        return false;
-    }
-
-    // Check for infinitive linking loops
-    if (leftChain.indexOf(x) > -1 || rightChain.indexOf(y) > -1) {
-         return false;
-    }
-
-    // Quick checking of one object beeing a subset of another.
-    // todo: cache the structure of arguments[0] for performance
-    for (p in y) {
-        if (y.hasOwnProperty(p) !== x.hasOwnProperty(p)) {
-            return false;
-        }
-        else if (typeof y[p] !== typeof x[p]) {
-            return false;
-        }
-    }
-
-    for (p in x) {
-        if (y.hasOwnProperty(p) !== x.hasOwnProperty(p)) {
-            return false;
-        }
-        else if (typeof y[p] !== typeof x[p]) {
-            return false;
-        }
-
-        switch (typeof (x[p])) {
-            case 'object':
-            case 'function':
-
-                leftChain.push(x);
-                rightChain.push(y);
-
-                if (!compare2Objects (x[p], y[p])) {
-                    return false;
-                }
-
-                leftChain.pop();
-                rightChain.pop();
-                break;
-
-            default:
-                if (x[p] !== y[p]) {
-                    return false;
-                }
-                break;
-        }
-    }
-
-    return true;
-  }
-
-  if (arguments.length < 1) {
-    return true; //Die silently? Don't know how to handle such case, please help...
-    // throw "Need two or more arguments to compare";
-  }
-
-  for (i = 1, l = arguments.length; i < l; i++) {
-
-      leftChain = []; //Todo: this can be cached
-      rightChain = [];
-
-      if (!compare2Objects(arguments[0], arguments[i])) {
-          return false;
-      }
-  }
-
-  return true;
-}

--- a/js/lib/lodlive.core.js
+++ b/js/lib/lodlive.core.js
@@ -450,7 +450,7 @@
           connectedWeblinks.push(newVal);
         }
       } else {
-        types.push(unescape(value));
+        types.push(value);
       }
     });
 
@@ -467,7 +467,7 @@
 
     renderedBnodes.forEach(function(obj) {
       destBox.append(obj.bnodeNode);
-      inst.resolveBnodes(unescape(obj.value), URI, obj.spanNode, destBox);
+      inst.resolveBnodes(obj.value, URI, obj.spanNode, destBox);
     });
   };
 
@@ -499,7 +499,7 @@
 
           var nestedBnodeNode = inst.renderer.docInfoNestedBnodes(key, spanNode);
 
-          inst.resolveBnodes(unescape(value), URI, nestedBnodeNode, destBox);
+          inst.resolveBnodes(value, URI, nestedBnodeNode, destBox);
         });
 
         // // TODO: slimScroll is no long included, and seems to be unnecessary
@@ -527,7 +527,7 @@
     $.each(map, function(skey, value) {
       for (var akey in value) {
         if (akey == key) {
-          returnVal.push(unescape(value[akey]));
+          returnVal.push(value[akey]);
         }
       }
     });
@@ -684,11 +684,11 @@
       var titleValues;
 
       if (title.indexOf('http') !== 0) {
-        titlePieces.push($.trim(unescape(title)));
+        titlePieces.push($.trim(title));
       } else {
         titleValues = inst.getJsonValue(values, title, title.indexOf('http') === 0 ? '' : title);
         titleValues.forEach(function(titleValue) {
-          titlePieces.push(unescape(titleValue));
+          titlePieces.push(titleValue);
         });
       }
     });
@@ -912,39 +912,19 @@
       success : function(info) {
         // reformat values for compatility
 
-        // escape values
-        info.values = info.values.map(function(value) {
-          var keys = Object.keys(value)
-          keys.forEach(function(key) {
-            value[key] = escape(value[key])
-          })
-          return value
-        });
-
-        // TODO: filter info.uris where object value === anURI (??)
-
-        // escape URIs
-        info.uris = info.uris.map(function(value) {
-          var keys = Object.keys(value)
-          keys.forEach(function(key) {
-            value[key] = escape(value[key])
-          })
-          return value
-        });
-
-        // parse bnodes, escape and add to URIs
-
         // TODO: refactor `format()` and remove this
         info.bnodes.forEach(function(bnode) {
           var keys = Object.keys(bnode)
           var value = {};
           keys.forEach(function(key) {
-            value[key] = escape(anUri + '~~' + bnode[key])
+            value[key] = anUri + '~~' + bnode[key];
           })
           info.uris.push(value);
         })
 
         delete info.bnodes;
+
+        // TODO: filter info.uris where object value === anURI (??)
 
         // s/b unnecessary
         // destBox.children('.box').html('');
@@ -959,27 +939,8 @@
             return inst.renderer.loading(destBox.children('.box'));
           },
           success : function(inverseInfo) {
-            // escape values
-            inverseInfo.values = inverseInfo.values.map(function(value) {
-              var keys = Object.keys(value)
-              keys.forEach(function(key) {
-                value[key] = escape(value[key])
-              })
-              return value
-            });
-
-            // escape URIs
-            inverseInfo.uris = inverseInfo.uris.map(function(value) {
-              var keys = Object.keys(value)
-              keys.forEach(function(key) {
-                value[key] = escape(value[key])
-              })
-              return value
-            });
-
+            // TODO: skip values?
             inverses = inverseInfo.uris.concat(inverseInfo.values);
-
-            // parse bnodes, escape and add to URIs
 
             // parse bnodes and add to URIs
             // TODO: refactor `format()` and remove this
@@ -1032,7 +993,7 @@
         $.each(json, function(key, value) {
           var newObj = {};
           var key = value.property && value.property.value || 'http://www.w3.org/2002/07/owl#sameAs';
-          newObj[key] = escape(value.object.value);
+          newObj[key] = value.object.value;
           // TODO: why the 2nd array element?
           inverse.splice(1, 0, newObj);
         });

--- a/js/lib/lodlive.core.js
+++ b/js/lib/lodlive.core.js
@@ -1063,38 +1063,8 @@
     var objectList = connectedNodes.objectList.concat(invertedNodes.objectList);
     var innerObjectList = connectedNodes.innerObjectList.concat(invertedNodes.innerObjectList);
 
-    var page = 0;
-    var totPages = objectList.length > 14 ? (objectList.length / 14 + (objectList.length % 14 > 0 ? 1 : 0)) : 1;
-    for (var i = 0; i < objectList.length; i++) {
-      if (i % 14 == 0) {
-        page++;
-        var aPage = $('<div class="page page' + page + '" style="display:none"></div>');
-        if (page > 1 && totPages > 1) {
-          aPage.append('<div class="llpages pagePrev sprite" data-page="page' + (page - 1) + '" style="top:' + (chordsList[0][1] - 8) + 'px;left:' + (chordsList[0][0] - 8) + 'px"></div>');
-        }
-        if (totPages > 1 && page < totPages - 1) {
-          aPage.append('<div class="llpages pageNext sprite" data-page="page' + (page + 1) + '" style="top:' + (chordsList[15][1] - 8) + 'px;left:' + (chordsList[15][0] - 8) + 'px"></div>');
-        }
-        containerBox.append(aPage);
-      }
-      containerBox.children('.page' + page).append(objectList[i]);
-    }
-    page = 0;
-    totPages = innerObjectList.length / 24 + (innerObjectList.length % 24 > 0 ? 1 : 0);
-    if (innerObjectList.length > 0) {
-      containerBox.append('<div class="innerPage"></div>');
-      for (var i = 0; i < innerObjectList.length; i++) {
-        containerBox.children('.innerPage').append(innerObjectList[i]);
-      }
-    }
-    containerBox.children('.page1').fadeIn('fast');
-    containerBox.children('.page').children('.llpages').click(function() {
-      var llpages = $(this);
-      containerBox.find('.lastClick').removeClass('lastClick').click();
-      llpages.parent().fadeOut('fast', null, function() {
-        $(this).parent().children('.' + llpages.attr('data-page')).fadeIn('fast');
-      });
-    });
+    // paginate and display the related boxes
+    inst.renderer.paginateRelatedBoxes(containerBox, objectList, innerObjectList, chordsList);
 
     // append the tools
     inst.renderer.generateNodeIcons(anchorBox);

--- a/js/lib/lodlive.core.js
+++ b/js/lib/lodlive.core.js
@@ -768,9 +768,12 @@
     var propertyGroup = {};
     var propertyGroupInverted = {};
 
-    var connectedImages = [];
-    var connectedLongs = [];
-    var connectedLats = [];
+    // Image rendering has been disabled; keeping for posterity ...
+    // var connectedImages = [];
+
+    // Map rendering has been disabled; keeping for posterity ...
+    // var connectedLongs = [];
+    // var connectedLats = [];
 
     var sameDocControl = [];
     $.each(uris, function(key, value) {
@@ -851,54 +854,76 @@
         }
       });
     }
-    if (inst.doDrawMap) {
-      for (var a = 0; a < points.length; a++) {
-        var resultArray = inst.getJsonValue(values, points[a], points[a]);
-        for (var af = 0; af < resultArray.length; af++) {
-          if (resultArray[af].indexOf(' ') != -1) {
-            eval('connectedLongs.push(\'' + unescape(resultArray[af].split(' ')[1]) + '\')');
-            eval('connectedLats.push(\'' + unescape(resultArray[af].split(' ')[0]) + '\')');
-          } else if (resultArray[af].indexOf('-') != -1) {
-            eval('connectedLongs.push(\'' + unescape(resultArray[af].split('-')[1]) + '\')');
-            eval('connectedLats.push(\'' + unescape(resultArray[af].split('-')[0]) + '\')');
-          }
-        }
-      }
-      for (var a = 0; a < longs.length; a++) {
-        var resultArray = inst.getJsonValue(values, longs[a], longs[a]);
-        for (var af = 0; af < resultArray.length; af++) {
-          eval('connectedLongs.push(\'' + unescape(resultArray[af]) + '\')');
-        }
-      }
-      for (var a = 0; a < lats.length; a++) {
-        var resultArray = inst.getJsonValue(values, lats[a], lats[a]);
-        for (var af = 0; af < resultArray.length; af++) {
-          eval('connectedLats.push(\'' + unescape(resultArray[af]) + '\')');
-        }
-      }
 
-      if (connectedLongs.length > 0 && connectedLats.length > 0) {
-        var mapsMap = inst.mapsMap;
-        mapsMap[containerBox.attr('id')] = {
-          longs : connectedLongs[0],
-          lats : connectedLats[0],
-          title : thisUri + '\n' + escape(resourceTitle)
-        };
-        inst.updateMapPanel(inst.context.find('.lodlive-controlPanel'));
-      }
-    }
-    if (inst.doCollectImages) {
-      if (connectedImages.length > 0) {
-        var imagesMap = inst.imagesMap;
-        imagesMap[containerBox.attr('id')] = connectedImages;
-        inst.updateImagePanel(inst.context.find('.lodlive-controlPanel'));
-      }
-    }
-    var totRelated = connectedDocs.length + invertedDocs.length;
+    function groupByObject(inputArray, type) {
+      var tmpIRIs = {};
+      var outputArray = [];
 
-    // se le proprieta' da mostrare sono troppe cerco di accorpare
-    // quelle uguali
-    if (totRelated > 16) {
+      inputArray.forEach(function(uriObj) {
+        // TODO: ensure only one key?
+        var property = Object.keys(uriObj)[0];
+        var object = uriObj[property];
+        var newObj = {};
+        var newKey, previousKey, previousIndex;
+
+        // Image rendering has been disabled; keeping for posterity ...
+        // if (type === 'uris' && images.indexOf(property) > -1) {
+        //   newObj[property] = escape(resourceTitle);
+        //   connectedImages.push(newObj);
+        //   return;
+        // }
+
+        // skip `weblinks` properties
+        if (type === 'uris' && weblinks.indexOf(property) > -1) return;
+
+        // TODO: checking for bnode of bnode?
+        if (type === 'inverses' && docType == 'bnode' && object.indexOf('~~') > -1) return;
+
+        // group by object
+        if (tmpIRIs.hasOwnProperty(object)) {
+          previousIndex = tmpIRIs[object];
+          previousKey = Object.keys(outputArray[ previousIndex ])[0]
+          newKey = previousKey + ' | ' + property;
+          newObj[ newKey ] = object;
+          outputArray[ previousIndex ] = newObj;
+        } else {
+          outputArray.push(uriObj);
+          tmpIRIs[object] = outputArray.length - 1;
+        }
+      });
+
+      return outputArray;
+    }
+
+    var myConnectedDocs = [];
+    var myInvertedDocs = [];
+
+    myConnectedDocs = groupByObject(uris, 'uris');
+    if (inverses) {
+      myInvertedDocs = groupByObject(inverses, 'inverses');
+    }
+
+    var myConnectedEqual = deepCompare(connectedDocs, myConnectedDocs);
+    console.log('connected: ' + myConnectedEqual)
+    if (!myConnectedEqual) {
+      connectedDocs.forEach(function(obj, i) {
+        if (!deepCompare(obj, myConnectedDocs[i])) {
+          console.log(obj, myConnectedDocs[i])
+        }
+      })
+    }
+
+    var myInvertedEqual = deepCompare(invertedDocs, myInvertedDocs)
+    console.log('inverted: ' + myInvertedEqual)
+    if (!myInvertedEqual) {
+      invertedDocs.forEach(function(obj, i) {
+        if (!deepCompare(obj, myInvertedDocs[i])) {
+          console.log(obj, myInvertedDocs[i])
+        }
+      })
+    }
+
+    // if (totRelated > 16) {
       $.each(connectedDocs, function(key, value) {
         for (var akey in value) {
           if (propertyGroup[akey]) {
@@ -921,45 +946,338 @@
           }
         }
       });
-      totRelated = 0;
-      for (var prop in propertyGroup) {
-        if (propertyGroup.hasOwnProperty(prop)) {
-          totRelated++;
+    //   totRelated = 0;
+    //   for (var prop in propertyGroup) {
+    //     if (propertyGroup.hasOwnProperty(prop)) {
+    //       totRelated++;
+    //     }
+    //   }
+    //   for (var prop in propertyGroupInverted) {
+    //     if (propertyGroupInverted.hasOwnProperty(prop)) {
+    //       totRelated++;
+    //     }
+    //   }
+    // }
+
+    function groupByPropertyKey(inputArray) {
+      var group = {};
+
+      // group URIs by property key
+      inputArray.forEach(function(uriObj) {
+        // TODO: ensure only one key?
+        var property = Object.keys(uriObj)[0];
+        var object = uriObj[property];
+
+        if (group.hasOwnProperty(property)) {
+          group[property].push(object);
+        } else {
+          group[property] = [object];
         }
-      }
-      for (var prop in propertyGroupInverted) {
-        if (propertyGroupInverted.hasOwnProperty(prop)) {
-          totRelated++;
-        }
-      }
+      });
+
+      return group;
     }
 
-    // calcolo le parti in cui dividere il cerchio per posizionare i
-    // link
+    // group URIs by property key
+    var myPropertyGroup = groupByPropertyKey(connectedDocs);
+    // group inverse URIs by property key
+    var myPropertyGroupInverted = groupByPropertyKey(invertedDocs);
+
+    var myGroupEqual = deepCompare(propertyGroup, myPropertyGroup);
+    console.log('group: ' + myGroupEqual)
+    if (!myGroupEqual) {
+      Object.keys(propertyGroup).forEach(function(key) {
+        if (!deepCompare(propertyGroup[key], myPropertyGroup[key])) {
+          console.log(propertyGroup[key], myPropertyGroup[key])
+        }
+      })
+    }
+
+    var myInvertedGroupEqual = deepCompare(propertyGroupInverted, myPropertyGroupInverted)
+    console.log('inverted group: ' + myInvertedGroupEqual)
+    if (!myInvertedGroupEqual) {
+      Object.keys(propertyGroupInverted).forEach(function(key) {
+        if (!deepCompare(propertyGroupInverted[key], myPropertyGroupInverted[key])) {
+          console.log(propertyGroupInverted[key], myPropertyGroupInverted[key])
+        }
+      })
+    }
+
+    // Map rendering has been disabled; keeping for posterity ...
+    // if (inst.doDrawMap) {
+    //   for (var a = 0; a < points.length; a++) {
+    //     var resultArray = inst.getJsonValue(values, points[a], points[a]);
+    //     for (var af = 0; af < resultArray.length; af++) {
+    //       if (resultArray[af].indexOf(' ') != -1) {
+    //         eval('connectedLongs.push(\'' + unescape(resultArray[af].split(' ')[1]) + '\')');
+    //         eval('connectedLats.push(\'' + unescape(resultArray[af].split(' ')[0]) + '\')');
+    //       } else if (resultArray[af].indexOf('-') != -1) {
+    //         eval('connectedLongs.push(\'' + unescape(resultArray[af].split('-')[1]) + '\')');
+    //         eval('connectedLats.push(\'' + unescape(resultArray[af].split('-')[0]) + '\')');
+    //       }
+    //     }
+    //   }
+    //   for (var a = 0; a < longs.length; a++) {
+    //     var resultArray = inst.getJsonValue(values, longs[a], longs[a]);
+    //     for (var af = 0; af < resultArray.length; af++) {
+    //       eval('connectedLongs.push(\'' + unescape(resultArray[af]) + '\')');
+    //     }
+    //   }
+    //   for (var a = 0; a < lats.length; a++) {
+    //     var resultArray = inst.getJsonValue(values, lats[a], lats[a]);
+    //     for (var af = 0; af < resultArray.length; af++) {
+    //       eval('connectedLats.push(\'' + unescape(resultArray[af]) + '\')');
+    //     }
+    //   }
+
+    //   if (connectedLongs.length > 0 && connectedLats.length > 0) {
+    //     var mapsMap = inst.mapsMap;
+    //     mapsMap[containerBox.attr('id')] = {
+    //       longs : connectedLongs[0],
+    //       lats : connectedLats[0],
+    //       title : thisUri + '\n' + escape(resourceTitle)
+    //     };
+    //     inst.updateMapPanel(inst.context.find('.lodlive-controlPanel'));
+    //   }
+    // }
+
+    // Image rendering has been disabled; keeping for posterity ...
+    // if (inst.doCollectImages) {
+    //   if (connectedImages.length > 0) {
+    //     var imagesMap = inst.imagesMap;
+    //     imagesMap[containerBox.attr('id')] = connectedImages;
+    //     inst.updateImagePanel(inst.context.find('.lodlive-controlPanel'));
+    //   }
+    // }
+
+    // No longer used; keeping for posterity ...
+    // totRelated = Object.keys(propertyGroup).length +
+    //              Object.keys(propertyGroupInverted).length;
+
+    // calcolo le parti in cui dividere il cerchio per posizionare i link
     // var chordsList = this.lodlive('circleChords',
     // destBox.width() / 2 + 12, ((totRelated > 1 ? totRelated - 1 :
     // totRelated) * 2) + 4, destBox.position().left + destBox.width() /
     // 2, destBox.position().top + destBox.height() / 2, totRelated +
     // 4);
-    //
+
     var chordsList = inst.circleChords(75, 24, destBox.position().left + 65, destBox.position().top + 65);
     var chordsListGrouped = inst.circleChords(95, 36, destBox.position().left + 65, destBox.position().top + 65);
+
+    // console.log(chordsList)
+    // console.log(chordsListGrouped)
+
+    var counterSanityCheck = {
+      group: [],
+      related: []
+    }
+    var newCounterSanityCheck = {
+      group: [],
+      related: []
+    }
+
+    function createPropertyBoxes(inputArray, inputGroup, isInverse) {
+      var a = 1;
+      var inserted = {};
+      var innerCounter = 1;
+      var objectList = [];
+      var innerObjectList = [];
+
+      inputArray.forEach(function(value, i) {
+        // TODO: refactor; modular arithmetic for CSS positioning
+        // a appears to equal the count of groupedProperties mod 14 plus 1 or 2
+        if (a === 15) {
+          a = 1;
+        }
+
+        // TODO: ensure only one key?
+        var akey = Object.keys(value)[0];
+        var obj = null;
+
+        if (inputGroup[akey] && inputGroup[akey].length > 1) {
+          if (!inserted[akey]) {
+            innerCounter = 1;
+            inserted[akey] = true;
+
+            var objBox = createPropertyGroup(akey, inputGroup[akey], a, isInverse);
+            objectList.push(objBox);
+            newCounterSanityCheck.related.push(a)
+
+            a++;
+          }
+
+          // TODO: magic number; why 25?
+          if (innerCounter < 25) {
+            obj = createGroupedRelatedBox(akey, value[akey], innerCounter, isInverse);
+            newCounterSanityCheck.group.push(innerCounter)
+          }
+
+          innerCounter++;
+        } else {
+          obj = createRelatedBox(akey, value[akey], a, isInverse);
+          newCounterSanityCheck.related.push(a)
+          a++;
+        }
+
+        // TODO: when will object be null? innerCounter >= 25?
+        if (obj) {
+          addRelatedBoxProperties(obj, akey, containerBox, isInverse);
+
+          if (obj.hasClass('aGrouped')) {
+            innerObjectList.push(obj);
+          } else {
+            objectList.push(obj);
+          }
+        }
+      });
+
+      return {
+        objectList: objectList,
+        innerObjectList: innerObjectList
+      }
+    }
+
+    // create a node to represent a group of related properties (star-circle)
+    function createPropertyGroup(akey, groupValue, aCounter, isInverse) {
+      var objBox = $('<div></div>')
+
+      objBox.addClass('groupedRelatedBox')
+      objBox.attr('rel', inst.hashFunc(akey))
+      objBox.attr('data-property', akey)
+      objBox.attr('data-title', akey + ' \n ' + (groupValue.length) + ' ' + utils.lang('connectedResources'))
+      objBox.css(inst.getRelationshipCSS(akey));
+
+      if (isInverse) {
+        objBox.addClass('inverse')
+        objBox.attr('rel', inst.hashFunc(akey) + '-i')
+      }
+
+      var akeyArray = akey.split(' ');
+
+      if (unescape(groupValue[0]).indexOf('~~') != -1) {
+        objBox.addClass('isBnode');
+      } else {
+        for (var i = 0; i < akeyArray.length; i++) {
+          if (lodLiveProfile.arrows[akeyArray[i]]) {
+            objBox.addClass(lodLiveProfile.arrows[akeyArray[i]]);
+          }
+        }
+      }
+
+      objBox.css({
+        'top':  (chordsList[aCounter][1] - 8) + 'px',
+        'left': (chordsList[aCounter][0] - 8) + 'px'
+      });
+
+      return objBox;
+    }
+
+    // create a node to represent a property in a group of related properties
+    function createGroupedRelatedBox(akey, keyedValue, innerCounter, isInverse) {
+      var rel;
+
+      // TODO: this seems inlikely... the bnode marker isn't ever at the beginning of keyedValue
+      // is the condition a typo?
+      if (isInverse) {
+        rel = unescape(keyedValue.indexOf('~~') == 0 ? thisUri + keyedValue : keyedValue);
+      } else {
+        rel = unescape(keyedValue)
+      }
+
+      var obj = $('<div></div>')
+
+      obj.addClass('aGrouped relatedBox');
+      obj.attr('rel', rel)
+      obj.attr('data-title', akey + ' \n ' + unescape(keyedValue))
+      obj.attr('data-circlePos', innerCounter);
+      obj.attr('data-circleParts', 36);
+      // obj.css({
+      //   display: 'none',
+      //   position: 'absolute',
+      //   top: (chordsListGrouped[innerCounter][1] - 8) + 'px',
+      //   left: (chordsListGrouped[innerCounter][0] - 8) + 'px'
+      // });
+      obj.attr('style', 'display: none; position: absolute; top: ' + (chordsListGrouped[innerCounter][1] - 8) + 'px; left: ' + (chordsListGrouped[innerCounter][0] - 8) + 'px;');
+
+      if (isInverse) {
+        obj.addClass('inverse ' + inst.hashFunc(akey) + '-i')
+      } else {
+        obj.addClass(inst.hashFunc(akey).toString())
+      }
+
+      obj.addClass(inst.hashFunc(unescape(keyedValue)).toString())
+
+      return obj;
+    }
+
+    // create a node to represent a related property
+    function createRelatedBox(akey, keyedValue, aCounter, isInverse) {
+      var obj = $('<div></div>')
+
+      obj.addClass('relatedBox')
+      obj.attr('rel', unescape(keyedValue))
+      obj.attr('data-title', akey + ' \n ' + unescape(keyedValue))
+      obj.attr('data-circlePos', aCounter);
+      obj.attr('data-circleParts', 24);
+      // obj.css({
+      //   top: (chordsList[a][1] - 8) + 'px',
+      //   left: (chordsList[a][0] - 8) + 'px'
+      // })
+      obj.attr('style', 'top: ' + (chordsList[aCounter][1] - 8) + 'px; left: ' + (chordsList[aCounter][0] - 8) + 'px;');
+
+      if (isInverse) {
+        obj.addClass('inverse')
+      }
+
+      obj.addClass(inst.hashFunc(unescape(keyedValue)).toString())
+
+      return obj;
+    }
+
+    function addRelatedBoxProperties(obj, akey, containerBox, isInverse) {
+      obj.attr('data-circleid', containerBox.attr('id'));
+      obj.attr('data-property', akey);
+      obj.css(inst.getRelationshipCSS(akey));
+      // se si tratta di un  Bnode applico una classe diversa
+      var akeyArray = akey.split(' ');
+      if (obj.attr('rel').indexOf('~~') != -1) {
+        obj.addClass('isBnode');
+      } else {
+        for (var i = 0; i < akeyArray.length; i++) {
+          if (lodLiveProfile.arrows[akeyArray[i]]) {
+            obj.addClass(lodLiveProfile.arrows[akeyArray[i]]);
+          }
+        }
+      }
+    }
+
+    var connectedDocsLists = createPropertyBoxes(connectedDocs, propertyGroup, false);
+    var invertedDocsLists = createPropertyBoxes(invertedDocs, propertyGroupInverted, true);
+
     // aggiungo al box i link ai documenti correlati
+    var objectList = [];
+    var innerObjectList = [];
+
     var a = 1;
     var inserted = {};
     var counter = 0;
     var innerCounter = 1;
 
-    var objectList = [];
-    var innerObjectList = [];
+    var isInverse = false;
+
     $.each(connectedDocs, function(key, value) {
+
+      // TODO: remove; appears to be unused
       if (counter == 16) {
         counter = 0;
       }
+
+      // TODO: refactor; modular arithmetic for CSS positioning
       if (a == 1) {
       } else if (a == 15) {
         a = 1;
       }
+
       for (var akey in value) {
         var obj = null;
         if (propertyGroup[akey] && propertyGroup[akey].length > 1) {
@@ -983,6 +1301,13 @@
               'top':  (chordsList[a][1] - 8) + 'px',
               'left': (chordsList[a][0] - 8) + 'px'
             });
+
+            var myObjBox = createPropertyGroup(akey, propertyGroup[akey], a, isInverse);
+            if (!deepCompare(objBox[0].outerHTML, myObjBox[0].outerHTML)) {
+              console.log(objBox[0].outerHTML)
+              console.log(myObjBox[0].outerHTML)
+            }
+
             objectList.push(objBox);
 
             a++;
@@ -992,19 +1317,37 @@
           if (innerCounter < 25) {
             obj = $('<div class="aGrouped relatedBox ' + inst.hashFunc(akey) + ' ' + inst.hashFunc(unescape(value[akey])) + '" rel="' + unescape(value[akey]) + '"  data-title="' + akey + ' \n ' + unescape(value[akey]) + '" ></div>');
             // containerBox.append(obj);
-            obj.attr('style', 'display:none;position:absolute;top:' + (chordsListGrouped[innerCounter][1] - 8) + 'px;left:' + (chordsListGrouped[innerCounter][0] - 8) + 'px');
             obj.attr('data-circlePos', innerCounter);
             obj.attr('data-circleParts', 36);
+            obj.attr('style', 'display: none; position: absolute; top: ' + (chordsListGrouped[innerCounter][1] - 8) + 'px; left: ' + (chordsListGrouped[innerCounter][0] - 8) + 'px;');
             obj.attr('data-circleid', containerBox.attr('id'));
+
+            var myObj = createGroupedRelatedBox(akey, value[akey], innerCounter, isInverse);
+            // if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
+            //   console.log(obj[0].outerHTML)
+            //   console.log(myObj[0].outerHTML)
+            // }
+
+            counterSanityCheck.group.push(innerCounter)
+
           }
 
           innerCounter++;
         } else {
-          obj = $('<div class="relatedBox ' + inst.hashFunc(unescape(value[akey])) + '" rel="' + unescape(value[akey]) + '"   data-title="' + akey + ' \n ' + unescape(value[akey]) + '" ></div>');
+          obj = $('<div class="relatedBox ' + inst.hashFunc(unescape(value[akey])) + '" rel="' + unescape(value[akey]) + '" data-title="' + akey + ' \n ' + unescape(value[akey]) + '"></div>');
           // containerBox.append(obj);
-          obj.attr('style', 'top:' + (chordsList[a][1] - 8) + 'px;left:' + (chordsList[a][0] - 8) + 'px');
           obj.attr('data-circlePos', a);
           obj.attr('data-circleParts', 24);
+          obj.attr('style', 'top: ' + (chordsList[a][1] - 8) + 'px; left: ' + (chordsList[a][0] - 8) + 'px;');
+
+          var myObj = createRelatedBox(akey, value[akey], a, isInverse);
+          // if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
+          //   console.log(obj[0].outerHTML)
+          //   console.log(myObj[0].outerHTML)
+          // }
+
+          counterSanityCheck.related.push(a)
+
           a++;
           counter++;
         }
@@ -1023,6 +1366,14 @@
               }
             }
           }
+
+          addRelatedBoxProperties(myObj, akey, containerBox, isInverse);
+
+          if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
+            console.log(obj[0].outerHTML)
+            console.log(myObj[0].outerHTML)
+          }
+
           if (obj.hasClass('aGrouped')) {
             innerObjectList.push(obj);
           } else {
@@ -1033,15 +1384,43 @@
 
     });
 
+    console.log('connectedDocs/object: ' + objectList.length)
+    console.log('connectedDocs/newObject: ' + connectedDocsLists.objectList.length)
+
+    objectList.forEach(function(obj, i) {
+      if (!deepCompare(obj[0].outerHTML, connectedDocsLists.objectList[i][0].outerHTML)) {
+        console.log(obj[0].outerHTML)
+        console.log(connectedDocsLists.objectList[i][0].outerHTML)
+      }
+    })
+
+    console.log('connectedDocs/innerObject: ' + innerObjectList.length)
+    console.log('connectedDocs/newInnerObject: ' + connectedDocsLists.innerObjectList.length)
+
+    innerObjectList.forEach(function(obj, i) {
+      if (!deepCompare(obj[0].outerHTML, connectedDocsLists.innerObjectList[i][0].outerHTML)) {
+        console.log(obj[0].outerHTML)
+        console.log(connectedDocsLists.innerObjectList[i][0].outerHTML)
+      }
+    })
+
+    isInverse = true;
+    a = 1;
+
     inserted = {};
     $.each(invertedDocs, function(key, value) {
+
+      // TODO: remove; appears to be unused
       if (counter == 16) {
         counter = 0;
       }
+
+      // TODO: refactor; modular arithmetic for CSS positioning
       if (a == 1) {
       } else if (a == 15) {
         a = 1;
       }
+
       for (var akey in value) {
         var obj = null;
         if (propertyGroupInverted[akey] && propertyGroupInverted[akey].length > 1) {
@@ -1067,6 +1446,12 @@
               'left': + (chordsList[a][0] - 8) + 'px'
             });
 
+            var myObjBox = createPropertyGroup(akey, propertyGroupInverted[akey], a, isInverse);
+            if (!deepCompare(objBox[0].outerHTML, myObjBox[0].outerHTML)) {
+              console.log(objBox[0].outerHTML)
+              console.log(myObjBox[0].outerHTML)
+            }
+
             objectList.push(objBox);
             a++;
             counter++;
@@ -1074,21 +1459,38 @@
 
           if (innerCounter < 25) {
             var destUri = unescape(value[akey].indexOf('~~') == 0 ? thisUri + value[akey] : value[akey]);
-            obj = $('<div class="aGrouped relatedBox inverse ' + inst.hashFunc(akey) + '-i ' + inst.hashFunc(unescape(value[akey])) + ' " rel="' + destUri + '"  data-title="' + akey + ' \n ' + unescape(value[akey]) + '" ></div>');
+            obj = $('<div class="aGrouped relatedBox inverse ' + inst.hashFunc(akey) + '-i ' + inst.hashFunc(unescape(value[akey])) + '" rel="' + destUri + '"  data-title="' + akey + ' \n ' + unescape(value[akey]) + '" ></div>');
             // containerBox.append(obj);
-            obj.attr('style', 'display:none;position:absolute;top:' + (chordsListGrouped[innerCounter][1] - 8) + 'px;left:' + (chordsListGrouped[innerCounter][0] - 8) + 'px');
             obj.attr('data-circlePos', innerCounter);
             obj.attr('data-circleParts', 36);
-            obj.attr('data-circleId', containerBox.attr('id'));
+            // obj.attr('data-circleId', containerBox.attr('id'));
+            obj.attr('style', 'display: none; position: absolute; top: ' + (chordsListGrouped[innerCounter][1] - 8) + 'px; left: ' + (chordsListGrouped[innerCounter][0] - 8) + 'px;');
+
+            var myObj = createGroupedRelatedBox(akey, value[akey], innerCounter, isInverse);
+            if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
+              console.log(obj[0].outerHTML)
+              console.log(myObj[0].outerHTML)
+            }
+
+            counterSanityCheck.group.push(innerCounter)
           }
 
           innerCounter++;
         } else {
           obj = $('<div class="relatedBox inverse ' + inst.hashFunc(unescape(value[akey])) + '" rel="' + unescape(value[akey]) + '"   data-title="' + akey + ' \n ' + unescape(value[akey]) + '" ></div>');
           // containerBox.append(obj);
-          obj.attr('style', 'top:' + (chordsList[a][1] - 8) + 'px;left:' + (chordsList[a][0] - 8) + 'px');
           obj.attr('data-circlePos', a);
           obj.attr('data-circleParts', 24);
+          obj.attr('style', 'top: ' + (chordsList[a][1] - 8) + 'px; left: ' + (chordsList[a][0] - 8) + 'px;');
+
+          var myObj = createRelatedBox(akey, value[akey], a, isInverse);
+          if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
+            console.log(obj[0].outerHTML)
+            console.log(myObj[0].outerHTML)
+          }
+
+          counterSanityCheck.related.push(a)
+
           a++;
           counter++;
         }
@@ -1109,6 +1511,13 @@
             }
           }
 
+          addRelatedBoxProperties(myObj, akey, containerBox, isInverse);
+
+          if (!deepCompare(obj[0].outerHTML, myObj[0].outerHTML)) {
+            console.log(obj[0].outerHTML)
+            console.log(myObj[0].outerHTML)
+          }
+
           if (obj.hasClass('aGrouped')) {
             innerObjectList.push(obj);
           } else {
@@ -1118,6 +1527,38 @@
       }
 
     });
+
+    // objectList = connectedDocsLists.objectList.concat(invertedDocsLists.objectList);
+    // innerObjectList = connectedDocsLists.innerObjectList.concat(invertedDocsLists.innerObjectList);
+
+    var combinedObjects = connectedDocsLists.objectList.concat(invertedDocsLists.objectList);
+    var combinedInnerObjects = connectedDocsLists.innerObjectList.concat(invertedDocsLists.innerObjectList)
+
+    console.log('objects: ' + objectList.length)
+    console.log('newObjects: ' + combinedObjects.length)
+
+    objectList.forEach(function(obj, i) {
+      if (!deepCompare(obj[0].outerHTML, combinedObjects[i][0].outerHTML)) {
+        console.log(i)
+        console.log(obj[0].outerHTML)
+        console.log(combinedObjects[i][0].outerHTML)
+      }
+    })
+
+    console.log('innerObjects: ' + innerObjectList.length)
+    console.log('newInnerObjects: ' + combinedInnerObjects.length)
+
+    innerObjectList.forEach(function(obj, i) {
+      if (!deepCompare(obj[0].outerHTML, combinedInnerObjects[i][0].outerHTML)) {
+        console.log(i)
+        console.log(obj[0].outerHTML)
+        console.log(combinedInnerObjects[i][0].outerHTML)
+      }
+    })
+
+    objectList = connectedDocsLists.objectList.concat(invertedDocsLists.objectList);
+    innerObjectList = connectedDocsLists.innerObjectList.concat(invertedDocsLists.innerObjectList);
+
     var page = 0;
     var totPages = objectList.length > 14 ? (objectList.length / 14 + (objectList.length % 14 > 0 ? 1 : 0)) : 1;
     for (var i = 0; i < objectList.length; i++) {
@@ -1386,3 +1827,118 @@
   };
 
 })(jQuery);
+
+function deepCompare () {
+  var i, l, leftChain, rightChain;
+
+  function compare2Objects (x, y) {
+    var p;
+
+    // remember that NaN === NaN returns false
+    // and isNaN(undefined) returns true
+    if (isNaN(x) && isNaN(y) && typeof x === 'number' && typeof y === 'number') {
+         return true;
+    }
+
+    // Compare primitives and functions.
+    // Check if both arguments link to the same object.
+    // Especially useful on step when comparing prototypes
+    if (x === y) {
+        return true;
+    }
+
+    // Works in case when functions are created in constructor.
+    // Comparing dates is a common scenario. Another built-ins?
+    // We can even handle functions passed across iframes
+    if ((typeof x === 'function' && typeof y === 'function') ||
+       (x instanceof Date && y instanceof Date) ||
+       (x instanceof RegExp && y instanceof RegExp) ||
+       (x instanceof String && y instanceof String) ||
+       (x instanceof Number && y instanceof Number)) {
+        return x.toString() === y.toString();
+    }
+
+    // At last checking prototypes as good a we can
+    if (!(x instanceof Object && y instanceof Object)) {
+        return false;
+    }
+
+    if (x.isPrototypeOf(y) || y.isPrototypeOf(x)) {
+        return false;
+    }
+
+    if (x.constructor !== y.constructor) {
+        return false;
+    }
+
+    if (x.prototype !== y.prototype) {
+        return false;
+    }
+
+    // Check for infinitive linking loops
+    if (leftChain.indexOf(x) > -1 || rightChain.indexOf(y) > -1) {
+         return false;
+    }
+
+    // Quick checking of one object beeing a subset of another.
+    // todo: cache the structure of arguments[0] for performance
+    for (p in y) {
+        if (y.hasOwnProperty(p) !== x.hasOwnProperty(p)) {
+            return false;
+        }
+        else if (typeof y[p] !== typeof x[p]) {
+            return false;
+        }
+    }
+
+    for (p in x) {
+        if (y.hasOwnProperty(p) !== x.hasOwnProperty(p)) {
+            return false;
+        }
+        else if (typeof y[p] !== typeof x[p]) {
+            return false;
+        }
+
+        switch (typeof (x[p])) {
+            case 'object':
+            case 'function':
+
+                leftChain.push(x);
+                rightChain.push(y);
+
+                if (!compare2Objects (x[p], y[p])) {
+                    return false;
+                }
+
+                leftChain.pop();
+                rightChain.pop();
+                break;
+
+            default:
+                if (x[p] !== y[p]) {
+                    return false;
+                }
+                break;
+        }
+    }
+
+    return true;
+  }
+
+  if (arguments.length < 1) {
+    return true; //Die silently? Don't know how to handle such case, please help...
+    // throw "Need two or more arguments to compare";
+  }
+
+  for (i = 1, l = arguments.length; i < l; i++) {
+
+      leftChain = []; //Todo: this can be cached
+      rightChain = [];
+
+      if (!compare2Objects(arguments[0], arguments[i])) {
+          return false;
+      }
+  }
+
+  return true;
+}

--- a/js/lib/lodlive.core.js
+++ b/js/lib/lodlive.core.js
@@ -711,56 +711,43 @@
     // gestisco l'inserimento di messaggi di sistema come errori o altro
     titles.push('http://system/msg');
 
-    // aggiungo al box il titolo
-    var result = '<div class="boxTitle"><span class="ellipsis_text">';
-    for (var a = 0; a < titles.length; a++) {
-      var resultArray = inst.getJsonValue(values, titles[a], titles[a].indexOf('http') == 0 ? '' : titles[a]);
-      if (titles[a].indexOf('http') != 0) {
-        if (result.indexOf($.trim(unescape(titles[a])) + ' \n') == -1) {
-          result += $.trim(unescape(titles[a])) + ' \n';
-        }
-      } else {
-        for (var af = 0; af < resultArray.length; af++) {
-          if (result.indexOf(unescape(resultArray[af]) + ' \n') == -1) {
-            result += unescape(resultArray[af]) + ' \n';
-          }
-        }
-      }
+    var titlePieces = [];
 
-    }
-    var dataEndpoint = containerBox.attr('data-endpoint') || '';
+    titles.forEach(function(title) {
+      var titleValues;
+
+      if (title.indexOf('http') !== 0) {
+        titlePieces.push($.trim(unescape(title)));
+      } else {
+        titleValues = inst.getJsonValue(values, title, title.indexOf('http') === 0 ? '' : title);
+        titleValues.forEach(function(titleValue) {
+          titlePieces.push(unescape(titleValue));
+        });
+      }
+    });
+
+    var title = titlePieces
+    // deduplicate
+    .filter(function(value, index, self) {
+      return self.indexOf(value) === index;
+    })
+    .join('\n');
 
     // TODO: early return?
     if (uris.length == 0 && values.length == 0) {
-      result = '<div class="boxTitle" data-tooltip="' + utils.lang('resourceMissing') + '"><a target="_blank" href="' + thisUri + '"><span class="spriteLegenda"></span>' + thisUri + '</a>';
-    }
-
-    result += '</span></div>';
-    var jResult = $(result);
-    if (jResult.text() == '' && docType == 'bnode') {
-      jResult.text('[blank node]');
-    } else if (jResult.text() == '') {
-      var titleDef = '(Error)';
+      title = utils.lang('resourceMissing');
+    } else if (!title && docType === 'bnode') {
+      title = '[blank node]';
+    } else if (!title) {
+      title = '(Error)';
       try {
-          titleDef = inst.options.default.document.titleName[thisUri];
-      }catch(ex) {
-          titleDef = inst.options.default.document.titleProperties[thisUri];
-      }
-      if(titleDef){
-          jResult.text(titleDef);
-      } else {
-        jResult.text(utils.lang('noName'));
+        title = inst.options.default.document.titleName[thisUri];
+      } catch(ex) {
+        title = inst.options.default.document.titleProperties[thisUri];
       }
     }
-    destBox.append(jResult);
 
-    var resourceTitle = jResult.text();
-    jResult.data('tooltip', resourceTitle);
-
-    inst.renderer.hover(destBox, function() {
-      console.log('destbox hover title', resourceTitle);
-      inst.renderer.msg(resourceTitle, 'show', 'fullInfo', containerBox.attr('data-endpoint'));
-    });
+    inst.renderer.addBoxTitle(title, thisUri, destBox, containerBox);
 
     // calcolo le uri e le url dei documenti correlati
     var connectedDocs = [];

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -543,6 +543,74 @@ LodLiveRenderer.prototype.addBoxTitle = function(title, thisUri, destBox, contai
 };
 
 /**
+ * Paginates related boxes in `objectList` and `innerObjectList`
+ */
+LodLiveRenderer.prototype.paginateRelatedBoxes = function(containerBox, objectList, innerObjectList, chordsList) {
+  var page = 0;
+  var prevChords = chordsList[0];
+  var nextChords = chordsList[15];
+  var totPages = objectList.length > 14 ? (objectList.length / 14 + (objectList.length % 14 > 0 ? 1 : 0)) : 1;
+
+  objectList.forEach(function(objectListItem, i) {
+    var aPage, prevPage, nextPage;
+
+    if (i % 14 === 0) {
+      page++;
+
+      aPage = $('<div></div>')
+      .addClass('page page' + page)
+      .attr('style', 'display:none');
+
+      if (page > 1 && totPages > 1) {
+        prevPage = $('<div></div>')
+        .addClass('llpages pagePrev')
+        // TODO: can the icon be rotated?
+        // .addClass('fa fa-arrow-left')
+        .attr('data-page', 'page' + (page - 1))
+        .attr('style', 'top:' + (prevChords[1] - 8) + 'px;left:' + (prevChords[0] - 8) + 'px');
+
+        aPage.append(prevPage);
+      }
+
+      if (totPages > 1 && page < totPages - 1) {
+        nextPage = $('<div></div>')
+        .addClass('llpages pageNext')
+        // TODO: can the icon be rotated?
+        // .addClass('fa fa-arrow-right')
+        .attr('data-page', 'page' + (page + 1))
+        .attr('style', 'top:' + (nextChords[1] - 8) + 'px;left:' + (nextChords[0] - 8) + 'px');
+
+        aPage.append(nextPage);
+      }
+
+      containerBox.append(aPage);
+    }
+
+    containerBox.children('.page' + page).append(objectListItem);
+  });
+
+  var innerPage = $('<div class="innerPage"></div>');
+
+  innerObjectList.forEach(function(innerObject) {
+    innerPage.append(innerObject);
+  });
+
+  if (innerObjectList.length > 0) {
+    containerBox.append(innerPage);
+  }
+
+  containerBox.children('.page').children('.llpages').click(function() {
+    var llpages = $(this);
+    containerBox.find('.lastClick').removeClass('lastClick').click();
+    llpages.parent().fadeOut('fast', null, function() {
+      $(this).parent().children('.' + llpages.attr('data-page')).fadeIn('fast');
+    });
+  });
+
+  containerBox.children('.page1').fadeIn('fast');
+};
+
+/**
  * Gets all canvases containing lines related to `id`
  *
  * @param {String} id - the id of a subject or object node

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -511,6 +511,38 @@ LodLiveRenderer.prototype.docInfoNestedBnodes = function(key, spanNode) {
 };
 
 /**
+ * Add title to box
+ */
+LodLiveRenderer.prototype.addBoxTitle = function(title, thisUri, destBox, containerBox) {
+  var renderer = this;
+
+  var jResult = $('<div></div>')
+  .addClass('boxTitle');
+
+  // TODO: this is a hack; find some other way to catch this condition
+  if (title === utils.lang('resourceMissing')) {
+    jResult.append('<a target="_blank" href="' + thisUri + '">' + thisUri + '</a>')
+    // TODO: fa-external-link?
+    .append('<span class="spriteLegenda"></span>');
+  } else {
+    if (!title) {
+      title = utils.lang('noName');
+    }
+
+    var result = $('<span class="ellipsis_text"></span>');
+    result.text(title);
+    jResult.append(result);
+  }
+
+  jResult.attr('data-tooltip', title);
+  destBox.append(jResult);
+
+  renderer.hover(destBox, function() {
+    renderer.msg(title, 'show', 'fullInfo', containerBox.attr('data-endpoint'));
+  });
+};
+
+/**
  * Gets all canvases containing lines related to `id`
  *
  * @param {String} id - the id of a subject or object node

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -565,7 +565,7 @@ LodLiveRenderer.prototype.paginateRelatedBoxes = function(containerBox, objectLi
         prevPage = $('<div></div>')
         .addClass('llpages pagePrev')
         // TODO: can the icon be rotated?
-        // .addClass('fa fa-arrow-left')
+        .addClass('fa fa-arrow-left')
         .attr('data-page', 'page' + (page - 1))
         .attr('style', 'top:' + (prevChords[1] - 8) + 'px;left:' + (prevChords[0] - 8) + 'px');
 
@@ -576,7 +576,7 @@ LodLiveRenderer.prototype.paginateRelatedBoxes = function(containerBox, objectLi
         nextPage = $('<div></div>')
         .addClass('llpages pageNext')
         // TODO: can the icon be rotated?
-        // .addClass('fa fa-arrow-right')
+        .addClass('fa fa-arrow-right')
         .attr('data-page', 'page' + (page + 1))
         .attr('style', 'top:' + (nextChords[1] - 8) + 'px;left:' + (nextChords[0] - 8) + 'px');
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -310,8 +310,8 @@ LodLiveRenderer.prototype.docInfoImages = function(images) {
     var key = Object.keys(imgObj)[0];
     var value = imgObj[key];
 
-    var linkNode = $('<a></a>').attr('href', unescape(value));
-    var imgNode = $('<img/>').attr('src', unescape(value));
+    var linkNode = $('<a></a>').attr('href', value);
+    var imgNode = $('<img/>').attr('src', value);
 
     linkNode.append(imgNode);
     sectionNode.append(linkNode);
@@ -372,9 +372,9 @@ LodLiveRenderer.prototype.docInfoLinks = function(links) {
 
     var listItemNode = $('<li></li>');
     var linkNode = $('<a class="relatedLink" target="_blank"></a>')
-    .attr('data-title', key + ' \n ' + unescape(value))
-    .attr('href', unescape(value))
-    .text(unescape(value));
+    .attr('data-title', key + ' \n ' + value)
+    .attr('href', value)
+    .text(value);
 
     // TODO: delegate hover
     renderer.hover(linkNode);
@@ -620,7 +620,7 @@ LodLiveRenderer.prototype.createPropertyGroup = function createPropertyGroup(pre
     box.attr('rel', renderer.hashFunc(predicates).toString() + '-i');
   }
 
-  if (unescape(groupValue[0]).indexOf('~~') > -1) {
+  if (groupValue[0].indexOf('~~') > -1) {
     box.addClass('isBnode');
   } else {
     predicates.split(' ').forEach(function(predicate) {
@@ -674,9 +674,9 @@ LodLiveRenderer.prototype.createRelatedBox = function createRelatedBox(predicate
 LodLiveRenderer.prototype._createRelatedBox = function _createRelatedBox(predicates, object, containerBox, isInverse) {
   var renderer = this;
   var box = $('<div></div>')
-  .addClass('relatedBox ' + renderer.hashFunc(unescape(object)).toString())
-  .attr('rel', unescape(object))
-  .attr('data-title', predicates + ' \n ' + unescape(object))
+  .addClass('relatedBox ' + renderer.hashFunc(object).toString())
+  .attr('rel', object)
+  .attr('data-title', predicates + ' \n ' + object)
   .attr('data-circleid', containerBox.attr('id'))
   .attr('data-property', predicates)
   .css(renderer.getRelationshipCSS(predicates));
@@ -685,7 +685,7 @@ LodLiveRenderer.prototype._createRelatedBox = function _createRelatedBox(predica
     box.addClass('inverse');
   }
 
-  if (unescape(object).indexOf('~~') > -1) {
+  if (object.indexOf('~~') > -1) {
     box.addClass('isBnode');
   } else {
     predicates.split(' ').forEach(function(predicate) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,6 +46,27 @@ LodLiveUtils.shortenKey = function(str) {
   return lastSlash > lastHash ? str.substring(lastSlash + 1) : str.substring(lastHash + 1);
 };
 
+LodLiveUtils.circleChords = function(radius, steps, centerX, centerY, breakAt, onlyElement) {
+  var values = [];
+  var i = 0;
+  if (onlyElement) {
+    // ottimizzo i cicli evitando di calcolare elementi che non
+    // servono
+    i = onlyElement;
+    var radian = (2 * Math.PI) * (i / steps);
+    values.push([centerX + radius * Math.cos(radian), centerY + radius * Math.sin(radian)]);
+  } else {
+    for (; i < steps; i++) {
+      // calcolo le coodinate lungo il cerchio del box per
+      // posizionare
+      // strumenti ed altre risorse
+      var radian = (2 * Math.PI) * (i / steps);
+      values.push([centerX + radius * Math.cos(radian), centerY + radius * Math.sin(radian)]);
+    }
+  }
+  return values;
+};
+
 module.exports = LodLiveUtils;
 
 if (!window.LodLiveUtils) {


### PR DESCRIPTION
This PR is mostly about de-duplicating `format()`, while getting rid of `eval` and concatenated HTML strings. There's some pretty opaque iteration logic, and the extracted methods aren't ready to be moved to the renderer.

This might need some more work before it's merged ...
