### PR TITLE
Node mousedown swallowing events, preventing .relationBox clicks from firing

### DIFF
--- a/src/draggable.js
+++ b/src/draggable.js
@@ -43,7 +43,7 @@ function enableDrag(container, context, draggableSelector, dragStart) {
 
   container.on('mousedown', draggableSelector, function(event) {
     // mark the node as being dragged using event-delegation
-    dragState.target = $(this);
+    dragState.target = $(this).parent();
     dragState.panning = false;
 
     // store offset of event so node moves properly

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1282,7 +1282,7 @@ LodLiveRenderer.prototype.init = function(inst, container) {
 
   var draggable = require('./draggable.js');
 
-  draggable(this.container, this.context, '.lodlive-node', function(dragState) {
+  draggable(this.container, this.context, '.lodlive-node-label', function(dragState) {
     return renderer.reDrawLines(dragState.target);
   });
 


### PR DESCRIPTION
Added fix for intermittent issues with node main div swallowing all events.

As discussed here: https://github.com/grtjn/ml-lodlive-ng/issues/15