### PR TITLE
Configurable relationship number

### DIFF
--- a/js/lib/lodlive.core.js
+++ b/js/lib/lodlive.core.js
@@ -85,7 +85,7 @@
         nodeIcons: profile.UI.nodeIcons,
         relationships: profile.UI.relationships,
         hashFunc: profile.hashFunc, 
-        maxRelationshipsToRender: profile.maxRelationshipsToRender
+        maxRelationshipsToRender: profile.UI.maxRelationshipsToRender
       };
     }
 

--- a/js/lib/lodlive.core.js
+++ b/js/lib/lodlive.core.js
@@ -84,7 +84,8 @@
         tools: profile.UI.tools,
         nodeIcons: profile.UI.nodeIcons,
         relationships: profile.UI.relationships,
-        hashFunc: profile.hashFunc
+        hashFunc: profile.hashFunc, 
+        maxRelationshipsToRender: profile.maxRelationshipsToRender
       };
     }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -79,6 +79,7 @@ function LodLiveRenderer(options) {
   this.tools = options.tools;
   this.nodeIcons = options.nodeIcons;
   this.relationships = options.relationships;
+  this.maxRelationshipsToRender = options.maxRelationshipsToRender;
 }
 
 /**
@@ -909,7 +910,23 @@ LodLiveRenderer.prototype.drawLine = function(from, to, canvas, propertyName) {
     .filter(function(value, index, self) {
       return self.indexOf(value) === index;
     })
-    .join(', ');
+      
+    if(this.maxRelationshipsToRender !== undefined && label.length > this.maxRelationshipsToRender) {
+        var labelToRender = "";
+        for(var i = 0; i < this.maxRelationshipsToRender; i++) {
+            labelToRender += label[i]; 
+            if(i < this.maxRelationshipsToRender - 1) {
+                labelToRender += ", ";
+            }
+        }
+        labelToRender += " and " + (label.length - this.maxRelationshipsToRender ) + " more";
+        label = labelToRender;
+    } else {
+        label = label.join(", ");
+    }
+
+    line.label = label;
+    line.lineStyle = lineStyle;
 
     line.label = label;
     line.lineStyle = lineStyle;


### PR DESCRIPTION
As discussed in #53 

I'm using ml-lodlive over a very large dataset. Some of the entities have multiple (100s) relationships between them.
For example:

Sam is Bananas
Sam went Bananas
Sam ate Bananas
Sam dislikes Bananas
On my large dataset the label on the line between the two node circles can look crazy since it is rendering every single relationship.

This PR provides a new UI.maxRelationshipsToRender flag which when exceeded, renders " and N more" on the label.

For example, on the line between Sam and Bananas it would render "is, went and 2 more".